### PR TITLE
feat: add overview card and charts, implement callbacks for the outputs and dropdowns

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - pip:
       - dash-vega-components
       - kagglehub
+      - vl-convert-python=1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python==3.11.*
 ipykernel==6.29.5
 ipywidgets==8.1.5
 altair==5.5.0
+vl-convert-python==1.7.0

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,9 @@ import sys
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from dash import Dash, html
+import dash_bootstrap_components as dbc
+import dash_vega_components as dvc
+import src.callbacks
 from src.components import (
     currency_switch_btns,
     overview_company_dropdown,
@@ -35,15 +38,9 @@ app.layout = html.Div([
         overview_company_dropdown,
 
         # Visuals
-        html.Div("Placeholder for Summary Card", className='summary-card'),
-        html.Div(
-            "Placeholder for Number of Car Models in Each Company Bar Chart",
-            className='chart-placeholder'
-        ),
-        html.Div(
-            "Placeholder for Car Price Range Histogram for Selected Company",
-            className='chart-placeholder'
-        )
+        html.Div(id="max-speed-hp-card"),  # Max total speed & horsepower
+        dvc.Vega(id='cars-bar-chart'),  # Bar chart
+        dvc.Vega(id='price-range-histogram')  # Grouped histogram
     ], className='company-overview'),
 
     # Section 2: Detailed Analysis
@@ -94,4 +91,3 @@ app.layout = html.Div([
 # Run the app/dashboard
 if __name__ == '__main__':
     app.run(debug=True)  # Set to False before deployment
-    # server = app.server  # Uncomment this line for deployment

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -1,0 +1,91 @@
+from dash import Input, Output, callback, html
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.data import cars_df
+from src.components import (
+    currency_switch_btns,
+    overview_company_dropdown,
+    details_company_dropdown,
+    fuel_types_dropdown,
+    price_range_slider,
+    min_price_input,
+    max_price_input,
+    total_speed_range_slider,
+    min_total_speed_input,
+    max_total_speed_input,
+    seats_range_slider,
+    min_seats_input,
+    max_seats_input,
+    max_speed_horsepower,
+    plot_bar_chart,
+    plot_grouped_histogram
+)
+
+
+all_companies = sorted(cars_df['company_names'].unique())
+
+
+# Company dropdown limit selection to 5
+@callback(
+    Output('overview-company-dropdown', 'options'),
+    Input('overview-company-dropdown', 'value')
+)
+def limit_overview_dropdown_options(selected_companies):
+    if len(selected_companies) >= 5:
+        return [{'label': company, 'value': company, 'disabled': company not in selected_companies} for company in all_companies]
+    return [{'label': company, 'value': company} for company in all_companies]
+
+
+@callback(
+    Output('details-company-dropdown', 'options'),
+    Input('details-company-dropdown', 'value')
+)
+def limit_details_dropdown_options(selected_companies):
+    if len(selected_companies) >= 5:
+        return [{'label': company, 'value': company, 'disabled': company not in selected_companies} for company in all_companies]
+    return [{'label': company, 'value': company} for company in all_companies]
+
+
+@callback(
+    Output("max-speed-hp-card", "children"),
+    Input("overview-company-dropdown", "value")
+)
+def update_speed_hp_card(selected_companies):
+    if not selected_companies:
+        return "Select at least one company to view max speed & horsepower."
+
+    filtered_df = cars_df[cars_df['company_names'].isin(selected_companies)]
+    max_speed, max_hp = max_speed_horsepower(filtered_df)
+
+    if max_speed is None or max_hp is None:
+        return "No data available for selected companies."
+
+    return html.Div([
+        html.H3(f"{max_speed} KM/H"),
+        html.P("Max total speed"),
+        html.H3(f"{max_hp} HP"),
+        html.P("Max horsepower")
+    ])
+
+
+@callback(
+    Output('cars-bar-chart', 'spec'),
+    Input('overview-company-dropdown', 'value')
+)
+def update_bar_chart(selected_companies):
+    if not selected_companies:  
+        return {}
+    filtered_df = cars_df[cars_df['company_names'].isin(selected_companies)]
+    return plot_bar_chart(filtered_df)
+
+
+@callback(
+    Output('price-range-histogram', 'spec'),
+    Input('overview-company-dropdown', 'value')
+)
+def update_histogram(selected_companies):
+    if not selected_companies:  
+        return {}
+    filtered_df = cars_df[cars_df['company_names'].isin(selected_companies)]
+    return plot_grouped_histogram(filtered_df)


### PR DESCRIPTION
## Changes

- Implemented **summary card, bar chart, and grouped histogram**.  
  - The **bar chart** now includes a tooltip displaying **company name** and **car count** on hover.  
  - The **grouped histogram** tooltip now includes **company names, car count, and up to 14 car model names** (due to tooltip length constraints).  

- Added callbacks for **dropdown selection constraint** to **limit company selection to a maximum of 5**.  

- Implemented **callbacks for summary card, bar chart, and grouped histogram** to dynamically update based on selected companies.  
  - **[IMPORTANT]** If no valid data points exist for a selected condition, the chart now returns an **empty dictionary (`{}`)** to ensure a **blank plot**.  
    - e.g.:  
      <img width="300" alt="image" src="https://github.com/user-attachments/assets/489ab629-04f5-4dae-9e13-1ab3c29b92ce" />  

- **[IMPORTANT]** Added `vl-convert-python==1.7.0` to dependencies.  
  - Required for **correctly transforming Altair charts into Vega format** (`.to_dict(format="vega")`).  
  - **Please install using either `pip` or `conda`**. Command for pip: `pip install vl-convert-python==1.7.0`

After running `python src/app.py`, you should see something similar to this:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/d0d4e3b3-46f7-4621-bc85-4f9582b25b23" />