### PR TITLE
[render preview] Update chart widths to match the container size to make it more responsive on different screen sizes

### DIFF
--- a/src/components/outputs.py
+++ b/src/components/outputs.py
@@ -105,7 +105,7 @@ def plot_bar_chart(df):
             alt.Tooltip('count()', title='Count')
         ]
     ).properties(
-        width=450,
+        width="container",
         height=400
     ).interactive().to_dict(format="vega")
 
@@ -153,7 +153,7 @@ def plot_grouped_histogram(df, price_col, currency='CAD'):
             alt.Tooltip('cars_names:N', title="Car Models")
         ]
     ).properties(
-        width=450,
+        width="container",
         height=400
     ).configure_axisX(
         labelAngle=0
@@ -209,7 +209,7 @@ def horsepower_price(filtered_df, x_var, price_col):
                 alt.Tooltip("car_types", title="Car Type"),
             ]
         )
-        .properties(width=200, height=400)
+        .properties(width="container", height=400)
         .interactive()
     )
 
@@ -262,7 +262,7 @@ def plot_boxplot_price(df, category="company_names", price_col="cars_prices_cad"
     )
 
     price_boxplot = alt.layer(boxplot, whisker).properties(
-        width=200,
+        width="container",
         height=400
     ).to_dict(format="vega")
 
@@ -324,7 +324,7 @@ def plot_boxplot_horsepower(df, category="company_names", price_col="cars_prices
     )
 
     horsepower_boxplot = alt.layer(boxplot, whisker).properties(
-        width=200,
+        width="container",
         height=400
     ).to_dict(format="vega")
 


### PR DESCRIPTION
Address the layout and overlapping behavior of charts, based on these two peer feedback points:

- **Merari**: #79 When I first opened the app, the legends were squished and didn't fully fit the page (I had to zoom out), maybe it would be a good idea to make them smaller or scaled down with the plots. This was also the case for the displays of the "km/h" and "Seats" (under the sliders).

- **Yasmin**: #72 Readability and Layout - Some sections of the dashboard feel visually cluttered, making it harder to navigate. The spacing between elements, particularly in the "Company Overview" section, could be improved for better clarity. I suggested improvement: Increase padding and spacing between sections to enhance readability. Consider using bold headers for key sections (e.g., "Max Speed" and "Max Horsepower") to draw attention. Ensure consistent font sizes across labels, filters, and plots to maintain a clean look. This will improve user experience, making it easier for car buyers and automotive analysts to scan and interpret data quickly.